### PR TITLE
Add orderby list to the spec

### DIFF
--- a/libs/Polyrific.Project.Core/BaseService.cs
+++ b/libs/Polyrific.Project.Core/BaseService.cs
@@ -118,7 +118,7 @@ namespace Polyrific.Project.Core
             {
                 try
                 {
-                    _ = await Repository.Create(entity, userEmail, userDisplayName);
+                    _ = await Repository.Create(entity, userEmail, userDisplayName, true);
                 }
                 catch (Exception ex)
                 {

--- a/libs/Polyrific.Project.Core/BaseSpecification.cs
+++ b/libs/Polyrific.Project.Core/BaseSpecification.cs
@@ -41,9 +41,19 @@ namespace Polyrific.Project.Core
         public Expression<Func<TEntity, object>> OrderBy { get; }
 
         /// <summary>
+        /// List of "order by - ascending" criteria
+        /// </summary>
+        public List<Expression<Func<TEntity, object>>> OrderByList { get; }
+
+        /// <summary>
         /// Order by descending expresion of the specification
         /// </summary>
         public Expression<Func<TEntity, object>> OrderByDescending { get; }
+
+        /// <summary>
+        /// List of "order by - descending" criteria
+        /// </summary>
+        public List<Expression<Func<TEntity, object>>> OrderByDescendingList { get; }
 
         /// <summary>
         /// Includes expression list

--- a/libs/Polyrific.Project.Core/IRepository.cs
+++ b/libs/Polyrific.Project.Core/IRepository.cs
@@ -48,9 +48,10 @@ namespace Polyrific.Project.Core
         /// <param name="entity">New entity</param>
         /// <param name="userEmail">Email of current user (to be put in <c>CreatedBy</c> and <c>UpdatedBy</c>)</param>
         /// <param name="userDisplayName">Display Name of current user (to be put in <c>CreatedBy</c> and <c>UpdatedBy</c>)</param>
+        /// <param name="fillUpdatedInfo">Fill the <c>Updated</c> and <c>UpdatedBy</c> fields as well</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>Id of the new entity</returns>
-        Task<int> Create(TEntity entity, string userEmail = null, string userDisplayName = null, CancellationToken cancellationToken = default);
+        Task<int> Create(TEntity entity, string userEmail = null, string userDisplayName = null, bool fillUpdatedInfo = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Update an entity

--- a/libs/Polyrific.Project.Core/ISpecification.cs
+++ b/libs/Polyrific.Project.Core/ISpecification.cs
@@ -21,9 +21,19 @@ namespace Polyrific.Project.Core
         Expression<Func<TEntity, object>> OrderBy { get; }
 
         /// <summary>
+        /// List of "order by - ascending" criteria
+        /// </summary>
+        List<Expression<Func<TEntity, object>>> OrderByList { get; }
+
+        /// <summary>
         /// Order by descending criteria
         /// </summary>
         Expression<Func<TEntity, object>> OrderByDescending { get; }
+
+        /// <summary>
+        /// List of "order by - descending" criteria
+        /// </summary>
+        List<Expression<Func<TEntity, object>>> OrderByDescendingList { get; }
 
         /// <summary>
         /// Related entities to be included in the query

--- a/libs/Polyrific.Project.Core/Specification.cs
+++ b/libs/Polyrific.Project.Core/Specification.cs
@@ -43,11 +43,12 @@ namespace Polyrific.Project.Core
         /// Initiate the search specification
         /// </summary>
         /// <param name="criteria">Search criteria</param>
-        /// <param name="orderBy">The fields that will be used to sort the result</param>
-        /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order fields</param>
+        /// <param name="orderBy">The field that will be used to sort the result</param>
+        /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order field</param>
         /// <param name="skip">The number of items to skip</param>
         /// <param name="take">The maximum number of items to return</param>
-        public Specification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc, int skip, int take)
+        public Specification(Expression<Func<TEntity, bool>> criteria, 
+            Expression<Func<TEntity, object>> orderBy, bool orderDesc, int skip, int take)
         {
             Criteria = criteria;
 
@@ -65,6 +66,32 @@ namespace Polyrific.Project.Core
         }
 
         /// <summary>
+        /// Initiate the search specification
+        /// </summary>
+        /// <param name="criteria">Search criteria</param>
+        /// <param name="orderByList">The list of fields that will be used to sort the result</param>
+        /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order fields</param>
+        /// <param name="skip">The number of items to skip</param>
+        /// <param name="take">The maximum number of items to return</param>
+        public Specification(Expression<Func<TEntity, bool>> criteria, 
+            List<Expression<Func<TEntity, object>>> orderByList, bool orderDesc, int skip, int take)
+        {
+            Criteria = criteria;
+
+            if (orderDesc)
+            {
+                OrderByDescendingList = orderByList;
+            }
+            else
+            {
+                OrderByList = orderByList;
+            }
+
+            Skip = skip;
+            Take = take;
+        }
+
+        /// <summary>
         /// Criteria of the specification
         /// </summary>
         public Expression<Func<TEntity, bool>> Criteria { get; }
@@ -75,9 +102,19 @@ namespace Polyrific.Project.Core
         public Expression<Func<TEntity, object>> OrderBy { get; }
 
         /// <summary>
+        /// List of "order by - ascending" criteria
+        /// </summary>
+        public List<Expression<Func<TEntity, object>>> OrderByList { get; } = new List<Expression<Func<TEntity, object>>>();
+
+        /// <summary>
         /// Order by descending expresion of the specification
         /// </summary>
         public Expression<Func<TEntity, object>> OrderByDescending { get; }
+
+        /// <summary>
+        /// List of "order by - descending" criteria
+        /// </summary>
+        public List<Expression<Func<TEntity, object>>> OrderByDescendingList { get; } = new List<Expression<Func<TEntity, object>>>();
 
         /// <summary>
         /// Includes expression list

--- a/libs/Polyrific.Project.Data/DataRepository.cs
+++ b/libs/Polyrific.Project.Data/DataRepository.cs
@@ -44,12 +44,19 @@ namespace Polyrific.Project.Data
         }
 
         /// <inheritdoc/>
-        public virtual async Task<int> Create(TEntity entity, string userEmail = null, string userDisplayName = null, CancellationToken cancellationToken = default)
+        public virtual async Task<int> Create(TEntity entity, string userEmail = null, 
+            string userDisplayName = null, bool fillUpdatedInfo = false, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             entity.Created = DateTime.UtcNow;
             entity.CreatedBy = GetModifier(userEmail, userDisplayName);
+
+            if (fillUpdatedInfo)
+            {
+                entity.Updated = entity.Created;
+                entity.UpdatedBy = entity.CreatedBy;
+            }
 
             Db.Set<TEntity>().Add(entity);
             await Db.SaveChangesAsync(cancellationToken);
@@ -97,6 +104,32 @@ namespace Polyrific.Project.Data
             else if (spec.OrderByDescending != null)
             {
                 secondaryResult = secondaryResult.OrderByDescending(spec.OrderByDescending);
+            } 
+            else if (spec.OrderByList.Count > 0)
+            {
+                IOrderedQueryable<TEntity> orderedResult = null;
+                foreach (var orderBy in spec.OrderByList)
+                {
+                    if (orderedResult == null)
+                        orderedResult = secondaryResult.OrderBy(orderBy);
+
+                    orderedResult = orderedResult.ThenBy(orderBy);
+                }
+
+                secondaryResult = orderedResult;
+            }
+            else if (spec.OrderByDescendingList.Count > 0)
+            {
+                IOrderedQueryable<TEntity> orderedResult = null;
+                foreach (var orderByDescending in spec.OrderByDescendingList)
+                {
+                    if (orderedResult == null)
+                        orderedResult = secondaryResult.OrderByDescending(orderByDescending);
+
+                    orderedResult = orderedResult.ThenByDescending(orderByDescending);
+                }
+
+                secondaryResult = orderedResult;
             }
 
             // apply criteria and paging values
@@ -133,6 +166,32 @@ namespace Polyrific.Project.Data
             else if (spec.OrderByDescending != null)
             {
                 secondaryResult = secondaryResult.OrderByDescending(spec.OrderByDescending);
+            }
+            else if (spec.OrderByList.Count > 0)
+            {
+                IOrderedQueryable<TEntity> orderedResult = null;
+                foreach (var orderBy in spec.OrderByList)
+                {
+                    if (orderedResult == null)
+                        orderedResult = secondaryResult.OrderBy(orderBy);
+
+                    orderedResult = orderedResult.ThenBy(orderBy);
+                }
+
+                secondaryResult = orderedResult;
+            }
+            else if (spec.OrderByDescendingList.Count > 0)
+            {
+                IOrderedQueryable<TEntity> orderedResult = null;
+                foreach (var orderByDescending in spec.OrderByDescendingList)
+                {
+                    if (orderedResult == null)
+                        orderedResult = secondaryResult.OrderByDescending(orderByDescending);
+
+                    orderedResult = orderedResult.ThenByDescending(orderByDescending);
+                }
+
+                secondaryResult = orderedResult;
             }
 
             // return the result of the query using the specification's criteria expression


### PR DESCRIPTION
## Summary
- Add `OrderByList` and `OrderByDescendingList` to allow an entity collection to be sorted by more than one field.
- Add the option to fill the `Updated` and `UpdatedBy` fields in `Create` method.