### PR TITLE
Fix error when sorting column with type Date

### DIFF
--- a/libs/Polyrific.Project.Core/ExpressionBuilder.cs
+++ b/libs/Polyrific.Project.Core/ExpressionBuilder.cs
@@ -60,7 +60,7 @@ namespace Polyrific.Project.Core
             PropertyInfo property = typeof(T).GetProperty(orderBy, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
             MemberExpression member = Expression.Property(param, property);
 
-            return Expression.Lambda<Func<T, object>>(member, param);
+            return Expression.Lambda<Func<T, object>>(Expression.Convert(member, typeof(object)), param);
         }
 
         public static IList<Filter> BuildFilter(string filter, Op operation)

--- a/samples/2020/Test/Core/ProductServiceTests.cs
+++ b/samples/2020/Test/Core/ProductServiceTests.cs
@@ -167,6 +167,48 @@ namespace Test.Core
         }
 
         [Fact]
+        public async void GetProducts_OrderByUpdated_ReturnsItems()
+        {
+            _productRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<Product>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ISpecification<Product> spec, CancellationToken cancellationToken) =>
+                {
+                    var items = new List<Product> {
+                        new Product { Id = 1, Name = "zz", Updated = new System.DateTime(2020, 4, 22) },
+                        new Product { Id = 2, Name = "aa", Updated = new System.DateTime(2020, 4, 21) }
+                    }.AsQueryable();
+                    return items.OrderBy(spec.OrderBy).ToList();
+                });
+
+            var service = new ProductService(_productRepository.Object, _logger.Object);
+            var result = await service.GetPageData(orderBy: "updated");
+
+            Assert.NotEmpty(result.Items);
+            Assert.Equal(2, result.Items.Count());
+            Assert.Equal("aa", result.Items.First().Name);
+        }
+
+        [Fact]
+        public async void GetProducts_OrderById_ReturnsItems()
+        {
+            _productRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<Product>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ISpecification<Product> spec, CancellationToken cancellationToken) =>
+                {
+                    var items = new List<Product> {
+                        new Product { Id = 2, Name = "zz" },
+                        new Product { Id = 1, Name = "aa" }
+                    }.AsQueryable();
+                    return items.OrderBy(spec.OrderBy).ToList();
+                });
+
+            var service = new ProductService(_productRepository.Object, _logger.Object);
+            var result = await service.GetPageData(orderBy: "id");
+
+            Assert.NotEmpty(result.Items);
+            Assert.Equal(2, result.Items.Count());
+            Assert.Equal("aa", result.Items.First().Name);
+        }
+
+        [Fact]
         public async void GetProducts_ByName_ReturnsItems()
         {
             _productRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<Product>>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Summary
Fix the error in sorting when type column type is not string.

Known issue: the filter seems to only work for type `string` only. I have yet to find a way to dynamically create a linq criteria that support dynamic types