### PR TITLE
Support adding query selector to specification

### DIFF
--- a/libs/Polyrific.Project.Core/BaseSpecification.cs
+++ b/libs/Polyrific.Project.Core/BaseSpecification.cs
@@ -11,10 +11,9 @@ namespace Polyrific.Project.Core
     [Obsolete("Please use \"Specification\" instead which is not an abstract class.", false)]
     public abstract class BaseSpecification<TEntity> : ISpecification<TEntity> where TEntity : BaseEntity
     {
-        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, TEntity>> selector = null)
+        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria)
         {
             Criteria = criteria;
-            Selector = selector;
         }
 
         protected BaseSpecification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc = false, Expression<Func<TEntity, TEntity>> selector = null)

--- a/libs/Polyrific.Project.Core/BaseSpecification.cs
+++ b/libs/Polyrific.Project.Core/BaseSpecification.cs
@@ -11,12 +11,13 @@ namespace Polyrific.Project.Core
     [Obsolete("Please use \"Specification\" instead which is not an abstract class.", false)]
     public abstract class BaseSpecification<TEntity> : ISpecification<TEntity> where TEntity : BaseEntity
     {
-        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria)
+        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, TEntity>> selector = null)
         {
             Criteria = criteria;
+            Selector = selector;
         }
 
-        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc = false)
+        protected BaseSpecification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc = false, Expression<Func<TEntity, TEntity>> selector = null)
         {
             Criteria = criteria;
 
@@ -28,6 +29,8 @@ namespace Polyrific.Project.Core
             {
                 OrderBy = orderBy;
             }
+
+            Selector = selector;
         }
 
         /// <summary>
@@ -74,6 +77,11 @@ namespace Polyrific.Project.Core
         /// The maximum number of items to return
         /// </summary>
         public int? Take { get; private set; }
+
+        /// <summary>
+        /// Selector of the specification
+        /// </summary>
+        public Expression<Func<TEntity, TEntity>> Selector { get; }
 
         /// <summary>
         /// Adds include expression to the specification

--- a/libs/Polyrific.Project.Core/ISpecification.cs
+++ b/libs/Polyrific.Project.Core/ISpecification.cs
@@ -54,5 +54,10 @@ namespace Polyrific.Project.Core
         /// The maximum number of items to return
         /// </summary>
         int? Take { get; }
+
+        /// <summary>
+        /// Query selector
+        /// </summary>
+        Expression<Func<TEntity, TEntity>> Selector { get; }
     }
 }

--- a/libs/Polyrific.Project.Core/Specification.cs
+++ b/libs/Polyrific.Project.Core/Specification.cs
@@ -23,9 +23,21 @@ namespace Polyrific.Project.Core
         /// Initiate the search specification
         /// </summary>
         /// <param name="criteria">Search criteria</param>
+        /// <param name="selector">Query selector</param>
+        public Specification(Expression<Func<TEntity, TEntity>> selector, Expression<Func<TEntity, bool>> criteria)
+        {
+            Selector = selector;
+            Criteria = criteria;
+        }
+
+        /// <summary>
+        /// Initiate the search specification
+        /// </summary>
+        /// <param name="criteria">Search criteria</param>
         /// <param name="orderBy">The fields that will be used to sort the result</param>
         /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order fields</param>
-        public Specification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc = false)
+        /// <param name="selector">Query selector</param>
+        public Specification(Expression<Func<TEntity, bool>> criteria, Expression<Func<TEntity, object>> orderBy, bool orderDesc = false, Expression<Func<TEntity, TEntity>> selector = null)
         {
             Criteria = criteria;
 
@@ -37,6 +49,8 @@ namespace Polyrific.Project.Core
             {
                 OrderBy = orderBy;
             }
+
+            Selector = selector;
         }
 
         /// <summary>
@@ -47,8 +61,9 @@ namespace Polyrific.Project.Core
         /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order field</param>
         /// <param name="skip">The number of items to skip</param>
         /// <param name="take">The maximum number of items to return</param>
+        /// <param name="selector">Query selector</param>
         public Specification(Expression<Func<TEntity, bool>> criteria, 
-            Expression<Func<TEntity, object>> orderBy, bool orderDesc, int? skip, int? take)
+            Expression<Func<TEntity, object>> orderBy, bool orderDesc, int? skip, int? take, Expression<Func<TEntity, TEntity>> selector = null)
         {
             Criteria = criteria;
 
@@ -63,6 +78,8 @@ namespace Polyrific.Project.Core
 
             Skip = skip;
             Take = take;
+
+            Selector = selector;
         }
 
         /// <summary>
@@ -73,8 +90,9 @@ namespace Polyrific.Project.Core
         /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order fields</param>
         /// <param name="skip">The number of items to skip</param>
         /// <param name="take">The maximum number of items to return</param>
+        /// <param name="selector">Query selector</param>
         public Specification(Expression<Func<TEntity, bool>> criteria, 
-            List<Expression<Func<TEntity, object>>> orderByList, bool orderDesc, int? skip, int? take)
+            List<Expression<Func<TEntity, object>>> orderByList, bool orderDesc, int? skip, int? take, Expression<Func<TEntity, TEntity>> selector = null)
         {
             Criteria = criteria;
 
@@ -89,6 +107,8 @@ namespace Polyrific.Project.Core
 
             Skip = skip;
             Take = take;
+
+            Selector = selector;
         }
 
         /// <summary>
@@ -135,6 +155,11 @@ namespace Polyrific.Project.Core
         /// The maximum number of items to return
         /// </summary>
         public int? Take { get; private set; }
+
+        /// <summary>
+        /// Selector of the specification
+        /// </summary>
+        public Expression<Func<TEntity, TEntity>> Selector { get; }
 
         /// <summary>
         /// Adds include expression to the specification

--- a/libs/Polyrific.Project.Core/Specification.cs
+++ b/libs/Polyrific.Project.Core/Specification.cs
@@ -23,17 +23,6 @@ namespace Polyrific.Project.Core
         /// Initiate the search specification
         /// </summary>
         /// <param name="criteria">Search criteria</param>
-        /// <param name="selector">Query selector</param>
-        public Specification(Expression<Func<TEntity, TEntity>> selector, Expression<Func<TEntity, bool>> criteria)
-        {
-            Selector = selector;
-            Criteria = criteria;
-        }
-
-        /// <summary>
-        /// Initiate the search specification
-        /// </summary>
-        /// <param name="criteria">Search criteria</param>
         /// <param name="orderBy">The fields that will be used to sort the result</param>
         /// <param name="orderDesc">Whether to sort the result descendingly based on the defined order fields</param>
         /// <param name="selector">Query selector</param>

--- a/libs/Polyrific.Project.Data/DataRepository.cs
+++ b/libs/Polyrific.Project.Data/DataRepository.cs
@@ -135,6 +135,9 @@ namespace Polyrific.Project.Data
             // apply criteria and paging values
             secondaryResult = secondaryResult.Where(spec.Criteria);
 
+            if (spec.Selector != null)
+                secondaryResult = secondaryResult.Select(spec.Selector);
+
             // apply paging values
             if (spec.Skip.HasValue && spec.Take.HasValue)
                 secondaryResult = secondaryResult.Skip(spec.Skip.Value).Take(spec.Take.Value);
@@ -193,6 +196,9 @@ namespace Polyrific.Project.Data
 
                 secondaryResult = orderedResult;
             }
+
+            if (spec.Selector != null)
+                secondaryResult = secondaryResult.Select(spec.Selector);
 
             // return the result of the query using the specification's criteria expression
             return await secondaryResult

--- a/libs/Polyrific.Project.Test/Core/BaseServiceTests.cs
+++ b/libs/Polyrific.Project.Test/Core/BaseServiceTests.cs
@@ -123,7 +123,7 @@ namespace Polyrific.Project.Test.Core
         [Fact]
         public async void Save_New_CreateSuccess()
         {
-            _repository.Setup(r => r.Create(It.IsAny<DummyTestEntity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            _repository.Setup(r => r.Create(It.IsAny<DummyTestEntity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
 
             _repository.Setup(r => r.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -151,7 +151,7 @@ namespace Polyrific.Project.Test.Core
         [Fact]
         public async void Save_New_ThrowException()
         {
-            _repository.Setup(r => r.Create(It.IsAny<DummyTestEntity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            _repository.Setup(r => r.Create(It.IsAny<DummyTestEntity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new DummyException());
 
             var service = new DummyTestService(_repository.Object, _logger.Object);

--- a/samples/2020/Test/Data/DataRepositoryTests.cs
+++ b/samples/2020/Test/Data/DataRepositoryTests.cs
@@ -50,10 +50,10 @@ namespace Test.Data
         {
             using var dbContext = new ApplicationDbContext(ContextOptions);
             var productRepository = new DataRepository<Product>(dbContext);
-            var products = await productRepository.GetBySpec(new Specification<Product>(e => new Product
+            var products = await productRepository.GetBySpec(new Specification<Product>(e => true, null, selector: e => new Product
             {
                 Id = e.Id
-            }, e => true));
+            }));
 
             Assert.Equal(2, products.Count());
             Assert.True(!products.Any(e => e.Id == 0));
@@ -81,10 +81,10 @@ namespace Test.Data
         {
             using var dbContext = new ApplicationDbContext(ContextOptions);
             var productRepository = new DataRepository<Product>(dbContext);
-            var product = await productRepository.GetSingleBySpec(new Specification<Product>(e => new Product
+            var product = await productRepository.GetSingleBySpec(new Specification<Product>(e => true, null, selector: e => new Product
             {
                 Id = e.Id
-            }, e => true));
+            }));
 
             Assert.NotNull(product);
             Assert.Equal(1, product.Id);

--- a/samples/2020/Test/Data/DataRepositoryTests.cs
+++ b/samples/2020/Test/Data/DataRepositoryTests.cs
@@ -1,13 +1,94 @@
+using Core.Entities;
+using Data;
+using Microsoft.EntityFrameworkCore;
+using Polyrific.Project.Core;
+using Polyrific.Project.Data;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Test.Data
 {
     public class DataRepositoryTests
     {
-        [Fact]
-        public void GetById_ReturnItem()
+        public DataRepositoryTests()
         {
+            ContextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                    .UseInMemoryDatabase("sample-db")
+                    .Options;
 
+            Seed();
+        }
+
+        private DbContextOptions<ApplicationDbContext> ContextOptions { get; }
+
+        private void Seed()
+        {
+            using var context = new ApplicationDbContext(ContextOptions);
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            var one = new Product()
+            {
+                Id = 1,
+                Name = "Product 1"
+            };
+
+            var two = new Product()
+            {
+                Id = 2,
+                Name = "Product 2"
+            };
+
+            context.AddRange(one, two);
+
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task GetBySpec_ReturnItemsWithoutName()
+        {
+            using var dbContext = new ApplicationDbContext(ContextOptions);
+            var productRepository = new DataRepository<Product>(dbContext);
+            var products = await productRepository.GetBySpec(new Specification<Product>(e => new Product
+            {
+                Id = e.Id
+            }, e => true));
+
+            Assert.Equal(2, products.Count());
+            Assert.True(!products.Any(e => e.Id == 0));
+            Assert.True(!products.Any(e => e.Name != null));
+        }
+
+        [Fact]
+        public async Task GetBySpecWithOrder_ReturnItemsWithoutName()
+        {
+            using var dbContext = new ApplicationDbContext(ContextOptions);
+            var productRepository = new DataRepository<Product>(dbContext);
+            var products = await productRepository.GetBySpec(new Specification<Product>(e => true, e => e.Name, true, e => new Product
+            {
+                Id = e.Id
+            }));
+
+            Assert.True(products.First().Id == 2);
+            Assert.Equal(2, products.Count());
+            Assert.True(!products.Any(e => e.Id == 0));
+            Assert.True(!products.Any(e => e.Name != null));
+        }
+
+        [Fact]
+        public async Task GetSingleBySpec_ReturnItemWithoutName()
+        {
+            using var dbContext = new ApplicationDbContext(ContextOptions);
+            var productRepository = new DataRepository<Product>(dbContext);
+            var product = await productRepository.GetSingleBySpec(new Specification<Product>(e => new Product
+            {
+                Id = e.Id
+            }, e => true));
+
+            Assert.NotNull(product);
+            Assert.Equal(1, product.Id);
+            Assert.Null(product.Name);
         }
     }
 }

--- a/samples/2020/Test/Test.csproj
+++ b/samples/2020/Test/Test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
## Summary
Allows the `Specification` class to accepts `query selector`. This would be helpful if we want to only retrieve specific properties within an entity, for example if we want to avoid having to retrieve a column with huge size.